### PR TITLE
Minification resiliance

### DIFF
--- a/examples/minesweeper/src/data/GameBoard.js
+++ b/examples/minesweeper/src/data/GameBoard.js
@@ -198,4 +198,4 @@ class GameBoard extends DataComponent {
     }
 }
 
-export default connect(GameBoard);
+export default connect("GameBoard", GameBoard);

--- a/examples/minesweeper/src/data/GameClock.js
+++ b/examples/minesweeper/src/data/GameClock.js
@@ -51,4 +51,4 @@ class GameClock extends DataComponent {
     }
 }
 
-export default connect(GameClock);
+export default connect("GameClock", GameClock);

--- a/examples/minesweeper/src/data/GameMode.js
+++ b/examples/minesweeper/src/data/GameMode.js
@@ -74,4 +74,4 @@ class GameMode extends DataComponent {
     }
 }
 
-export default connect(GameMode);
+export default connect("GameMode", GameMode);

--- a/examples/static_data/src/data/PanelData.js
+++ b/examples/static_data/src/data/PanelData.js
@@ -35,4 +35,4 @@ class PanelData extends AsyncFetchComponent {
     }
 }
 
-export default connect(PanelData);
+export default connect("PanelData", PanelData);

--- a/examples/static_data/src/view/Sidebar.jsx
+++ b/examples/static_data/src/view/Sidebar.jsx
@@ -9,7 +9,7 @@ class Sidebar extends Component {
                 <ul>
                     {Object.keys(this.props)
                         .filter(key => this.props[key].state === 'LOADING')
-                        .map(key => <li>{key}</li>)}
+                        .map(key => <li key={key}>{key}</li>)}
                 </ul>
             </div>
         )

--- a/examples/static_data/yarn.lock
+++ b/examples/static_data/yarn.lock
@@ -2928,6 +2928,16 @@ he@1.1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
+history@^4.7.2:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.7.2.tgz#22b5c7f31633c5b8021c7f4a8a954ac139ee8d5b"
+  dependencies:
+    invariant "^2.2.1"
+    loose-envify "^1.2.0"
+    resolve-pathname "^2.2.0"
+    value-equal "^0.4.0"
+    warning "^3.0.0"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -2944,7 +2954,7 @@ hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
-hoist-non-react-statics@^2.2.1:
+hoist-non-react-statics@^2.2.1, hoist-non-react-statics@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
 
@@ -3169,7 +3179,7 @@ interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
-invariant@^2.0.0, invariant@^2.2.2:
+invariant@^2.0.0, invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -3969,7 +3979,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -4570,7 +4580,7 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
-path-to-regexp@^1.0.1:
+path-to-regexp@^1.0.1, path-to-regexp@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
   dependencies:
@@ -4992,7 +5002,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.6.0:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -5139,7 +5149,7 @@ react-dev-utils@^4.2.1:
     strip-ansi "3.0.1"
     text-table "0.2.0"
 
-react-dom@^16.2.0:
+react-dom@^16.0.0, react-dom@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
   dependencies:
@@ -5162,6 +5172,22 @@ react-redux@^5.0.6:
     lodash-es "^4.2.0"
     loose-envify "^1.1.0"
     prop-types "^15.5.10"
+
+react-router-redux@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-4.0.8.tgz#227403596b5151e182377dab835b5d45f0f8054e"
+
+react-router@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.2.0.tgz#61f7b3e3770daeb24062dae3eedef1b054155986"
+  dependencies:
+    history "^4.7.2"
+    hoist-non-react-statics "^2.3.0"
+    invariant "^2.2.2"
+    loose-envify "^1.3.1"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.5.4"
+    warning "^3.0.0"
 
 react-scripts@1.0.17:
   version "1.0.17"
@@ -5206,7 +5232,7 @@ react-scripts@1.0.17:
   optionalDependencies:
     fsevents "1.1.2"
 
-react@^16.2.0:
+react@^16.0.0, react@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
   dependencies:
@@ -5308,6 +5334,18 @@ reduce-function-call@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
   dependencies:
     balanced-match "^0.4.2"
+
+redux-data-components@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/redux-data-components/-/redux-data-components-0.1.0.tgz#782578e66e93e8a350415c85a746464fa2d391a8"
+  dependencies:
+    react "^16.0.0"
+    react-dom "^16.0.0"
+    react-redux "^5.0.6"
+    react-router "^4.2.0"
+    react-router-redux "^4.0.8"
+    redux "^3.7.2"
+    redux-persist "^5.4.0"
 
 redux-persist@^5.4.0:
   version "5.4.0"
@@ -5512,6 +5550,10 @@ resolve-from@^1.0.0:
 resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
+
+resolve-pathname@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
 
 resolve@1.1.7:
   version "1.1.7"
@@ -6318,6 +6360,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
+value-equal@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
+
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
@@ -6345,6 +6391,12 @@ walker@~1.0.5:
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
   dependencies:
     makeerror "1.0.x"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
 
 watch@~0.10.0:
   version "0.10.0"

--- a/src/DataComponent.js
+++ b/src/DataComponent.js
@@ -18,7 +18,7 @@ export default class DataComponent {
     // done so that multiple mounted instances of the same class can
     // operate independent of one another.
     componentIdentifier() {
-        return this.classOptions.id || this.constructor.name
+        return this.classOptions.id || this.constructor.DATA_COMPONENT
     }
 
     applyData(data) {

--- a/src/connect.js
+++ b/src/connect.js
@@ -1,6 +1,16 @@
 function createConnect() {
-    return (reducerClass) => {
-        reducerClass.DATA_COMPONENT = reducerClass.name;
+    return (defaultComponentId, reducerClass) => {
+        if(typeof reducerClass === 'undefined' && typeof defaultId !== 'string') {
+            console.warn(
+`Single-argument connect(Component) is deprecated and may not work correctly when minified.  Please convert to
+ connect("defaultComponentId", Component) for production code.  Suggest connect("MyComponent", MyComponent) for
+ consistency with existing behavior.`
+            );
+            reducerClass = defaultComponentId;
+            defaultComponentId = reducerClass.name;
+        }
+
+        reducerClass.DATA_COMPONENT = defaultComponentId;
 
         // Only generate a new instance if the class reducer returns updated data.
         function instanceReducer(oldInstance, action, classOptions) {

--- a/tests/unit/AsyncFetchComponentSpec.js
+++ b/tests/unit/AsyncFetchComponentSpec.js
@@ -26,6 +26,8 @@ describe('AsyncFetchComponent', () => {
     }
 
     function setup() {
+        TestFetchComponent.DATA_COMPONENT = 'TestFetchComponent';
+        ErrorFetchComponent.DATA_COMPONENT = 'ErrorFetchComponent';
         const dispatchSpy = jasmine.createSpy('dispatch');
         const component = makeComponent();
         let errorComponent = new ErrorFetchComponent();

--- a/tests/unit/DataComponentSpec.js
+++ b/tests/unit/DataComponentSpec.js
@@ -26,6 +26,7 @@ describe('DataComponent', () => {
         const initialBase = bootstrapBase.reduce(bootstrapBase, {});
         const bootstrapDerived = new DerivedComponent();
         const initialDerived = bootstrapDerived.reduce(bootstrapDerived, {});
+        DerivedComponent.DATA_COMPONENT = 'default-component-id';
         initialBase.props = { dispatch: dispatchSpy };
         initialDerived.props = { dispatch: dispatchSpy };
         return { bootstrapBase, bootstrapDerived, initialBase, initialDerived, dispatchSpy };
@@ -39,10 +40,10 @@ describe('DataComponent', () => {
     })
 
     describe('componentIdentifier', () => {
-        it('defaults to component name', () => {
+        it('defaults to static DATA_COMPONENT value', () => {
             const { initialBase, initialDerived } = setup();
-            expect(initialBase.componentIdentifier()).toEqual('DataComponent');
-            expect(initialDerived.componentIdentifier()).toEqual('DerivedComponent');
+            expect(initialBase.componentIdentifier()).toBeUndefined();
+            expect(initialDerived.componentIdentifier()).toEqual('default-component-id');
         })
 
         it('allows override using classOptions', () => {
@@ -80,11 +81,11 @@ describe('DataComponent', () => {
 
     describe('reset', () => {
         it('dispatches a reset action', () => {
-            const { initialBase, dispatchSpy } = setup();
-            initialBase.reset();
+            const { initialDerived, dispatchSpy } = setup();
+            initialDerived.reset();
             expect(dispatchSpy).toHaveBeenCalledWith({
                 type: ActionType.DATA_COMPONENT_RESET,
-                component: 'DataComponent'
+                component: 'default-component-id'
             });
         })
     })
@@ -168,7 +169,7 @@ describe('DataComponent', () => {
             });
             initialDerived.reduce(initialDerived, {
                 type: ActionType.DATA_COMPONENT_RESET,
-                component: 'DerivedComponent'
+                component: 'default-component-id'
             });
             expect(dataReducer).toHaveBeenCalledWith(undefined, {});
             expect(myReducer).toHaveBeenCalledWith(undefined, {});

--- a/tests/unit/connectSpec.js
+++ b/tests/unit/connectSpec.js
@@ -34,4 +34,22 @@ describe('connect', () => {
             expect(e.message).toEqual('MOCK FAILURE');
         }
     })
+
+    describe('minification support', () => {
+
+        it('accepts original syntax, with a warning', () => {
+            spyOn(console, 'warn')
+            const reducer = connect(MockComponent);
+            expect(console.warn).toHaveBeenCalled();
+            expect(MockComponent.DATA_COMPONENT).toEqual("MockComponent");
+        })
+
+        it('accepts new syntax, without a warning', () => {
+            spyOn(console, 'warn')
+            const reducer = connect('default-component-id', MockComponent);
+            expect(console.warn).not.toHaveBeenCalled();
+            expect(MockComponent.DATA_COMPONENT).toEqual("default-component-id");
+        })
+
+    })
 })


### PR DESCRIPTION
Dependence on classnames by default meant minification could cause conflicts between unrelated components.  Deprecated existing connect(Component) behavior in favor of an explicit default id, e.g., connect("Component", Component)